### PR TITLE
Fix typings export so that consuming apps can use "bundler" moduleResolution in tsconfig

### DIFF
--- a/library/package.json
+++ b/library/package.json
@@ -14,7 +14,10 @@
     "style": "./dist/dinesykmeldte-sidemeny.css",
     "exports": {
         ".": {
-            "import": "./dist/dinesykmeldte-sidemeny.js"
+            "import": {
+                "types": "./dist/main.d.ts",
+                "default": "./dist/dinesykmeldte-sidemeny.js"
+            }
         },
         "./dist/dinesykmeldte-sidemeny.css": {
             "import": "./dist/dinesykmeldte-sidemeny.css"


### PR DESCRIPTION
This typings export is necessary for typescript to not give errors when using the newer default `moduleResolution: bundler` in tsconfig in consuming apps and importing from this package.

bundler module resolution is a modern standard in tsconfig, and is necessary when importing certain components from Aksel. Specifically it is necessary when using next app router with server components where you can not use components with dot-notation, and importing Aksel components with their alternative non-dot notation. See http://aksel.nav.no/grunnleggende/kode/nextjs. Without bundler module resolution, and `moduleResolution: node10` instead in consuming apps, those apps must make all components using these aksel components into client components.

This way of specifying typings together with the `exports` field in package.json is "documented" in the second code example here: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-7.html#packagejson-exports-imports-and-self-referencing.