### PR TITLE
ci(pages): restore configure-pages step

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -26,8 +26,8 @@ jobs:
       - name: Build with Next.js
         run: pnpm build
         working-directory: ./example
-      - name: Deploy to GitHub Pages
-        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128
+      - name: Configure Pages
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b
       - name: Upload artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9
         with:


### PR DESCRIPTION
## Hva

Fikser den ødelagte GitHub Pages deploy-workflowen som har feilet siden pnpm-migrasjonen (feb 2026).

## Hvorfor

Under pnpm-migrasjonen (#215) ble `actions/configure-pages` feilaktig erstattet med `actions/deploy-pages` i `build`-jobben. Dette førte til at deploy ble forsøkt før artefakten var lastet opp — og workflowen har feilet på alle 20+ kjøringer siden.

## Endring

- Erstatter `actions/deploy-pages` med `actions/configure-pages@v5` (SHA-pinnet) i `build`-jobben
- `deploy`-jobben forblir uendret

## Verifisering

- Sammenlignet med fungerende versjon fra `b2339bf` (2026-01-08)
- SHA verifisert mot `actions/configure-pages` v5.0.0 release