### PR TITLE
build(deps): upgrade pnpm to 11.3.0

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,6 +1,6 @@
 [tools]
 node = "24"
-pnpm = "10"
+pnpm = "11.3.0"
 
 [tasks.install]
 description = "Install dependencies (cached)"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dinesykmeldte-sidemeny-root",
   "version": "1.0.0",
-  "packageManager": "pnpm@10.29.3",
+  "packageManager": "pnpm@11.3.0",
   "engines": {
     "node": ">=24"
   },

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,7 @@
 packages:
   - library
   - example
+allowBuilds:
+  esbuild: true
+  lefthook: false
+  sharp: false

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,3 +5,6 @@ allowBuilds:
   esbuild: true
   lefthook: false
   sharp: false
+
+minimumReleaseAge: 4320
+blockExoticSubdeps: true


### PR DESCRIPTION
## Beskrivelse

Oppgraderer repoets pnpm-versjon til `11.3.0` og legger til eksplisitt pnpm 11-godkjenning for dependency build scripts som CI nå krever.

## Endringer

- `package.json`: oppdaterer `packageManager` til `pnpm@11.3.0`
- `.mise.toml`: oppdaterer pnpm-verktøyversjon til `11.3.0`
- `pnpm-workspace.yaml`: legger til `allowBuilds` med minimal approval for pnpm 11 (`esbuild: true`, `lefthook: false`, `sharp: false`)
- `pnpm-lock.yaml`: verifisert med pnpm `11.3.0`; ingen lockfile-endringer nødvendige

## Issue

Closes #245

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)

## Verifisering

- `pnpm install --frozen-lockfile`
- `pnpm ignored-builds`
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- pre-push `typecheck` via lefthook ved `git push`

## Supply-chain-vurdering

- pnpm 11 blokkerer dependency build scripts til de er eksplisitt vurdert
- `esbuild` er godkjent fordi bibliotekets `vite build` er avhengig av esbuild-binær/install-script
- `lefthook` er eksplisitt avvist fordi repoet bare trenger root `prepare`-scriptet `lefthook install`; dependency sin egen `postinstall` er ikke nødvendig
- `sharp` er eksplisitt avvist fordi det kun er transitivt via Next-eksempelet og ikke trengs for repoets verifiserte `lint`, `test` eller bibliotek-`build`
- Ingen global åpning av build scripts eller nye avhengigheter ble introdusert